### PR TITLE
fix: update directory name from 'client' to 'frontend' in deployment script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
       # Step 7: Install dependencies and build Client app
       - name: Install & Build Client
         run: |
-          cd client
+          cd frontend
           npm ci
           npm run build
           rm -rf node_modules


### PR DESCRIPTION
update directory name from 'client' to 'frontend' in deployment script